### PR TITLE
Fixed multi-threading issue with sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Langcodes: a library for language codes
 
+
+** warning**
+For python2.x I forked this project and created more advanced version which is going to support caching (redis) and db supports (PostgreSQL, MySQL, MsSQL)
+
+Addition python packages are needed to make sure that this module can work
+* sqlalchemy
+* redis
+
+Module is thread and multiprocess safe
+
+
+
+
 **langcodes** knows what languages are. It knows the standardized codes that
 refer to them, such as `en` for English, `es` for Spanish and `hi` for Hindi.
 Often, it knows what these languages are called *in* a language, and that

--- a/langcodes/db.py
+++ b/langcodes/db.py
@@ -32,6 +32,9 @@ class LanguageDB:
     Some information that doesn't fit into the SQL schema is loaded lazily from
     .json files.
     """
+
+    self.condition = threading.Condition()
+
     TABLES = [
         """CREATE TABLE IF NOT EXISTS language(
             subtag TEXT PRIMARY KEY COLLATE NOCASE,
@@ -100,7 +103,8 @@ class LanguageDB:
 
         # Because this is Python 3, we can set `check_same_thread=False` and
         # get a database that can be safely read in multiple threads. Hooray!
-        self.conn = sqlite3.connect(db_filename, check_same_thread=False)
+        with self.condition:
+            self.conn = sqlite3.connect(db_filename, check_same_thread=False)
 
     def __str__(self):
         return "LanguageDB(%s)" % self.filename
@@ -109,18 +113,20 @@ class LanguageDB:
     # =========================================
 
     def setup(self):
-        for stmt in self.TABLES:
-            self.conn.execute(stmt)
-        self._make_indexes()
+        with self.condition:
+            for stmt in self.TABLES:
+                self.conn.execute(stmt)
+            self._make_indexes()
 
     def _make_indexes(self):
-        for table_name in self.NAMES_TO_INDEX:
-            self.conn.execute(
-                "CREATE UNIQUE INDEX IF NOT EXISTS {0}_uniq ON {0}(subtag, language, name)".format(table_name)
-            )
-            self.conn.execute(
-                "CREATE UNIQUE INDEX IF NOT EXISTS {0}_lookup ON {0}(subtag, language, name)".format(table_name)
-            )
+        with self.condition:
+            for table_name in self.NAMES_TO_INDEX:
+                self.conn.execute(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS {0}_uniq ON {0}(subtag, language, name)".format(table_name)
+                )
+                self.conn.execute(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS {0}_lookup ON {0}(subtag, language, name)".format(table_name)
+                )
 
     # Methods for building the database
     # =================================
@@ -130,7 +136,8 @@ class LanguageDB:
         template = "INSERT OR IGNORE INTO %s VALUES (%s)" % (table_name, tuple_template)
         # I know, right? The sqlite3 driver doesn't let you parameterize the
         # table name. Good thing little Bobby Tables isn't giving us the names.
-        self.conn.execute(template, values)
+        with self.condition:
+            self.conn.execute(template, values)
 
     def add_name(self, table, subtag, datalang, name, i):
         self._add_row('%s_name' % table, (subtag, datalang, name, i))
@@ -193,9 +200,10 @@ class LanguageDB:
     # =====================================
 
     def query(self, query, *args):
-        c = self.conn.cursor()
-        c.execute(query, args)
-        return c.fetchall()
+        with self.condition:
+            c = self.conn.cursor()
+            c.execute(query, args)
+            return c.fetchall()
 
     def list_macrolanguages(self):
         return self.query(
@@ -371,8 +379,9 @@ class LanguageDB:
     # =======================================
 
     def close(self):
-        self.conn.commit()
-        self.conn.close()
+        with self.condition:
+            self.conn.commit()
+            self.conn.close()
 
     def __enter__(self):
         return self

--- a/langcodes/db.py
+++ b/langcodes/db.py
@@ -1,5 +1,6 @@
 import sqlite3
 import json
+import threading
 from .util import data_filename
 
 
@@ -33,7 +34,7 @@ class LanguageDB:
     .json files.
     """
 
-    self.condition = threading.Condition()
+    condition = threading.Condition()
 
     TABLES = [
         """CREATE TABLE IF NOT EXISTS language(


### PR DESCRIPTION
There is serious problem with this module when you try to use it with code working in multi-threaded model. By using semaphore I tricked sqlite engine so it thinks that one thread a time accesses db hook.

Also tested with multiprocessing - works.