### PR TITLE
Update the IANA registry to 2016; fix an edge case

### DIFF
--- a/langcodes/__init__.py
+++ b/langcodes/__init__.py
@@ -117,6 +117,15 @@ class LanguageData:
         >>> LanguageData.get('root')
         LanguageData()
 
+        By default, getting a LanguageData object will automatically convert
+        deprecated tags:
+
+        >>> LanguageData.get('iw')
+        LanguageData(language='he')
+
+        >>> LanguageData.get('in')
+        LanguageData(language='id', macrolanguage='ms')
+
         One type of deprecated tag that should be replaced is for sign
         languages, which used to all be coded as regional variants of a
         fictitious global sign language called 'sgn'. Of course, there is no

--- a/langcodes/__init__.py
+++ b/langcodes/__init__.py
@@ -175,11 +175,17 @@ class LanguageData:
         >>> LanguageData.get('und-ibe')
         LanguageData(extlangs=['ibe'])
 
-        Here's an example of replacing multiple deprecated tags. The language
-        tag 'sh' (Serbo-Croatian) ended up being politically unsustainable or
-        something. It's been made into a macrolanguage *and* replaced with the
-        code 'sr-Latn'. We complicate the example by adding on the region tag
-        'QU', an old tag for the European Union, which is now standardized as
+        Here's an example of replacing multiple deprecated tags.
+
+        The language tag 'sh' (Serbo-Croatian) ended up being politically
+        problematic, and different standards took different steps to address
+        this. The IANA made it into a macrolanguage that contains 'sr', 'hr',
+        and 'bs'. Unicode further decided that it's a legacy tag that should
+        be interpreted as 'sr-Latn', which the language matching rules say
+        is mutually intelligible with all those languages.
+
+        We complicate the example by adding on the region tag 'QU', an old
+        provisional tag for the European Union, which is now standardized as
         'EU'.
 
         >>> LanguageData.get('sh-QU')

--- a/langcodes/__init__.py
+++ b/langcodes/__init__.py
@@ -579,7 +579,6 @@ class LanguageData:
 
         By default, things are named in English:
 
-        >>> from pprint import pprint
         >>> LanguageData.get('fr').language_name()
         'French'
         >>> LanguageData.get('el').language_name()
@@ -707,6 +706,18 @@ class LanguageData:
 
         >>> pprint(LanguageData.get('lol').fill_likely_values().describe())
         {'language': 'Mongo', 'region': 'Congo - Kinshasa', 'script': 'Latin'}
+
+        Sometimes the normalized and un-normalized versions of a language code
+        have different descriptions:
+
+        >>> LanguageData.get('mo')
+        LanguageData(language='ro', region='MD')
+
+        >>> pprint(LanguageData.get('mo').describe())
+        {'language': 'Romanian', 'region': 'Moldova'}
+
+        >>> pprint(LanguageData.get('mo', normalize=False).describe())
+        {'language': 'Moldavian'}
         """
         names = {}
         if self.language:

--- a/langcodes/__init__.py
+++ b/langcodes/__init__.py
@@ -98,11 +98,30 @@ class LanguageData:
         If normalize=True, non-standard or overlong tags will be replaced as
         they're interpreted. This is recommended.
 
+        Here are several examples of language codes, which are also test cases.
+        Most language codes are straightforward, but these examples will get
+        pretty obscure toward the end.
+
         >>> LanguageData.get('en-US')
         LanguageData(language='en', region='US')
 
-        >>> LanguageData.get('sh-QU')        # transform deprecated tags
-        LanguageData(language='sr', macrolanguage='sh', script='Latn', region='EU')
+        >>> LanguageData.get('zh-Hant')
+        LanguageData(language='zh', script='Hant')
+
+        >>> LanguageData.get('und')
+        LanguageData()
+
+        The non-code 'root' is sometimes used to represent the lack of any
+        language information, similar to 'und'.
+
+        >>> LanguageData.get('root')
+        LanguageData()
+
+        One type of deprecated tag that should be replaced is for sign
+        languages, which used to all be coded as regional variants of a
+        fictitious global sign language called 'sgn'. Of course, there is no
+        global sign language, so sign languages now have their own language
+        codes.
 
         >>> LanguageData.get('sgn-US')
         LanguageData(language='ase')
@@ -110,20 +129,61 @@ class LanguageData:
         >>> LanguageData.get('sgn-US', normalize=False)
         LanguageData(language='sgn', region='US')
 
+        Some macrolanguages have been divided into language codes for the
+        specific mutually-unintelligible languages they contain. Most
+        internationalization code continues to use the macrolanguage, such as
+        'zh' for Chinese, but data projects such as Wiktionary and Ethnologue
+        want to be more specific, so they use the codes that distinguish
+        languages, such as 'cmn' for Mandarin and 'yue' for Cantonese.
+
+        For this reason, LanguageData objects keep track of both the
+        macrolanguage and the specific language when they're allowed to
+        normalize the input.
+
         >>> LanguageData.get('zh-cmn-Hant')  # promote extlangs to languages
         LanguageData(language='cmn', macrolanguage='zh', script='Hant')
 
         >>> LanguageData.get('zh-cmn-Hant', normalize=False)
         LanguageData(language='zh', extlangs=['cmn'], script='Hant')
 
-        >>> LanguageData.get('und')
-        LanguageData()
+        'en-gb-oed' is a tag that's grandfathered into the standard because it
+        has been used to mean "spell-check this with Oxford English Dictionary
+        spelling", but that tag has the wrong shape. We interpret this as the
+        new standardized tag 'en-gb-oxendict', unless asked not to normalize.
 
-        >>> LanguageData.get('root')
-        LanguageData()
+        >>> LanguageData.get('en-gb-oed')
+        LanguageData(language='en', region='GB', variants=['oxendict'])
+
+        >>> LanguageData.get('en-gb-oed', normalize=False)
+        LanguageData(language='en-gb-oed')
+
+        'zh-min-nan' is another oddly-formed tag, used to represent the
+        Southern Min language, which includes Taiwanese as a regional form. It
+        now has its own language code.
+
+        >>> LanguageData.get('zh-min-nan')
+        LanguageData(language='nan', macrolanguage='zh')
+
+        There's not much we can do with the vague tag 'zh-min':
+
+        >>> LanguageData.get('zh-min')
+        LanguageData(language='zh-min')
+
+        Occasionally Wiktionary will use 'extlang' tags in strange ways, such
+        as using the tag 'und-ibe' for some unspecified Iberian language.
 
         >>> LanguageData.get('und-ibe')
         LanguageData(extlangs=['ibe'])
+
+        Here's an example of replacing multiple deprecated tags. The language
+        tag 'sh' (Serbo-Croatian) ended up being politically unsustainable or
+        something. It's been made into a macrolanguage *and* replaced with the
+        code 'sr-Latn'. We complicate the example by adding on the region tag
+        'QU', an old tag for the European Union, which is now standardized as
+        'EU'.
+
+        >>> LanguageData.get('sh-QU')
+        LanguageData(language='sr', macrolanguage='sh', script='Latn', region='EU')
         """
         data = {}
         # if the complete tag appears as something to normalize, do the

--- a/langcodes/__init__.py
+++ b/langcodes/__init__.py
@@ -167,6 +167,11 @@ class LanguageData:
                     data['region'] = DB.normalized_regions[value]
                 else:
                     data['region'] = value
+            elif typ == 'grandfathered':
+                # If we got here, we got a grandfathered tag but we were asked
+                # not to normalize it, or the DB doesn't know how to normalize
+                # it. The best we can do is set the entire tag as the language.
+                data['language'] = value
             else:
                 data[typ] = value
 

--- a/langcodes/data/language-subtag-registry.txt
+++ b/langcodes/data/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2014-04-10
+File-Date: 2016-02-10
 %%
 Type: language
 Subtag: aa
@@ -1214,6 +1214,8 @@ Type: language
 Subtag: aam
 Description: Aramanik
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: aas
 %%
 Type: language
 Subtag: aan
@@ -1580,6 +1582,8 @@ Type: language
 Subtag: adp
 Description: Adap
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: dz
 %%
 Type: language
 Subtag: adq
@@ -1651,6 +1655,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: aee
+Description: Northeast Pashai
 Description: Northeast Pashayi
 Added: 2009-07-29
 %%
@@ -2735,6 +2740,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: aot
+Description: Atong (India)
 Description: A'tong
 Added: 2009-07-29
 %%
@@ -3258,7 +3264,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: ato
-Description: Atong
+Description: Atong (Cameroon)
 Added: 2009-07-29
 %%
 Type: language
@@ -3340,6 +3346,8 @@ Type: language
 Subtag: aue
 Description: =/Kx'au//'ein
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: ktz
 %%
 Type: language
 Subtag: auf
@@ -5470,6 +5478,7 @@ Type: language
 Subtag: bmy
 Description: Bemba (Democratic Republic of Congo)
 Added: 2009-07-29
+Deprecated: 2015-02-12
 %%
 Type: language
 Subtag: bmz
@@ -6839,6 +6848,7 @@ Type: language
 Subtag: bxx
 Description: Borna (Democratic Republic of Congo)
 Added: 2009-07-29
+Deprecated: 2015-02-12
 %%
 Type: language
 Subtag: bxz
@@ -6966,6 +6976,7 @@ Type: language
 Subtag: byy
 Description: Buya
 Added: 2009-07-29
+Deprecated: 2015-02-12
 %%
 Type: language
 Subtag: byz
@@ -7297,6 +7308,12 @@ Type: language
 Subtag: cbo
 Description: Izora
 Added: 2009-07-29
+%%
+Type: language
+Subtag: cbq
+Description: Tsucuba
+Description: Cuba
+Added: 2015-02-12
 %%
 Type: language
 Subtag: cbr
@@ -10327,6 +10344,7 @@ Type: language
 Subtag: dzd
 Description: Daza
 Added: 2009-07-29
+Deprecated: 2015-02-12
 %%
 Type: language
 Subtag: dze
@@ -11943,6 +11961,8 @@ Type: language
 Subtag: gfx
 Description: Mangetti Dune !Xung
 Added: 2012-08-12
+Deprecated: 2015-02-12
+Preferred-Value: vaj
 %%
 Type: language
 Subtag: gga
@@ -12224,6 +12244,12 @@ Added: 2009-07-29
 Macrolanguage: kpe
 %%
 Type: language
+Subtag: gku
+Description: ǂUngkue
+Description: =/Ungkue
+Added: 2015-02-12
+%%
+Type: language
 Subtag: glc
 Description: Bon Gula
 Added: 2009-07-29
@@ -12235,6 +12261,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: glh
+Description: Northwest Pashai
 Description: Northwest Pashayi
 Added: 2009-07-29
 %%
@@ -12410,6 +12437,7 @@ Added: 2009-07-29
 Type: language
 Subtag: gnk
 Description: //Gana
+Description: ǁGana
 Added: 2009-07-29
 %%
 Type: language
@@ -12799,6 +12827,8 @@ Type: language
 Subtag: gti
 Description: Gbati-ri
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: nyc
 %%
 Type: language
 Subtag: gtu
@@ -13037,6 +13067,7 @@ Added: 2005-10-16
 Type: language
 Subtag: gwj
 Description: /Gwi
+Description: ǀGwi
 Added: 2009-07-29
 %%
 Type: language
@@ -13364,6 +13395,7 @@ Added: 2009-07-29
 Type: language
 Subtag: hgm
 Description: Hai//om
+Description: Haiǁom
 Added: 2009-07-29
 %%
 Type: language
@@ -13702,6 +13734,7 @@ Added: 2009-07-29
 Type: language
 Subtag: hnh
 Description: //Ani
+Description: ǁAni
 Added: 2009-07-29
 %%
 Type: language
@@ -13981,6 +14014,7 @@ Added: 2009-07-29
 Type: language
 Subtag: huc
 Description: =/Hua
+Description: ǂHua
 Added: 2009-07-29
 %%
 Type: language
@@ -14487,6 +14521,11 @@ Description: Ikaranggal
 Added: 2013-09-10
 %%
 Type: language
+Subtag: iks
+Description: Inuit Sign Language
+Added: 2015-02-12
+%%
+Type: language
 Subtag: ikt
 Description: Inuinnaqtun
 Description: Western Canadian Inuktitut
@@ -14579,6 +14618,7 @@ Type: language
 Subtag: ime
 Description: Imeraguen
 Added: 2009-07-29
+Deprecated: 2015-02-12
 %%
 Type: language
 Subtag: imi
@@ -15366,6 +15406,11 @@ Description: Buyuan Jinuo
 Added: 2009-07-29
 %%
 Type: language
+Subtag: jje
+Description: Jejueo
+Added: 2015-02-12
+%%
+Type: language
 Subtag: jjr
 Description: Bankal
 Added: 2012-08-12
@@ -15504,6 +15549,11 @@ Type: language
 Subtag: jod
 Description: Wojenaka
 Added: 2009-07-29
+%%
+Type: language
+Subtag: jog
+Description: Jogi
+Added: 2015-05-27
 %%
 Type: language
 Subtag: jor
@@ -15824,6 +15874,7 @@ Type: language
 Subtag: kbf
 Description: Kakauhua
 Added: 2009-07-29
+Deprecated: 2015-02-12
 %%
 Type: language
 Subtag: kbg
@@ -16925,6 +16976,11 @@ Description: Kashaya
 Added: 2009-07-29
 %%
 Type: language
+Subtag: kjv
+Description: Kaikavian Literary Language
+Added: 2015-02-12
+%%
+Type: language
 Subtag: kjx
 Description: Ramopa
 Added: 2009-07-29
@@ -17506,6 +17562,8 @@ Type: language
 Subtag: koj
 Description: Sara Dunjo
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: kwv
 %%
 Type: language
 Subtag: kok
@@ -18219,6 +18277,7 @@ Added: 2009-07-29
 Type: language
 Subtag: ktz
 Description: Ju/'hoan
+Description: Juǀʼhoan
 Added: 2009-07-29
 %%
 Type: language
@@ -18238,7 +18297,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: kue
-Description: Kuman
+Description: Kuman (Papua New Guinea)
 Added: 2009-07-29
 %%
 Type: language
@@ -18560,6 +18619,8 @@ Type: language
 Subtag: kwq
 Description: Kwak
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: yam
 %%
 Type: language
 Subtag: kwr
@@ -18633,6 +18694,8 @@ Type: language
 Subtag: kxe
 Description: Kakihum
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: tvd
 %%
 Type: language
 Subtag: kxf
@@ -19661,6 +19724,8 @@ Type: language
 Subtag: lii
 Description: Lingkhim
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: raq
 %%
 Type: language
 Subtag: lij
@@ -23536,6 +23601,8 @@ Type: language
 Subtag: mwj
 Description: Maligo
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: vaj
 %%
 Type: language
 Subtag: mwk
@@ -24092,6 +24159,7 @@ Added: 2005-10-16
 %%
 Type: language
 Subtag: naq
+Description: Khoekhoe
 Description: Nama (Namibia)
 Added: 2009-07-29
 %%
@@ -24107,6 +24175,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: nat
+Description: Ca̱hungwa̱rya̱
 Description: Hungworo
 Added: 2009-07-29
 %%
@@ -24672,6 +24741,7 @@ Added: 2009-07-29
 Type: language
 Subtag: ngh
 Description: N/u
+Description: Nǀu
 Added: 2009-07-29
 %%
 Type: language
@@ -25380,6 +25450,7 @@ Added: 2009-07-29
 Type: language
 Subtag: nmn
 Description: !Xóõ
+Description: ǃXóõ
 Added: 2009-07-29
 %%
 Type: language
@@ -25425,6 +25496,7 @@ Added: 2009-07-29
 Type: language
 Subtag: nmw
 Description: Nimoa
+Description: Rifao
 Added: 2009-07-29
 %%
 Type: language
@@ -25556,6 +25628,8 @@ Type: language
 Subtag: nnx
 Description: Ngong
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: ngv
 %%
 Type: language
 Subtag: nny
@@ -25796,6 +25870,12 @@ Type: language
 Subtag: nre
 Description: Southern Rengma Naga
 Added: 2009-07-29
+%%
+Type: language
+Subtag: nrf
+Description: Jèrriais
+Description: Guernésiais
+Added: 2015-02-12
 %%
 Type: language
 Subtag: nrg
@@ -26305,6 +26385,11 @@ Type: language
 Subtag: nxn
 Description: Ngawun
 Added: 2009-07-29
+%%
+Type: language
+Subtag: nxo
+Description: Ndambomo
+Added: 2015-02-12
 %%
 Type: language
 Subtag: nxq
@@ -27309,6 +27394,8 @@ Type: language
 Subtag: oun
 Description: !O!ung
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: vaj
 %%
 Type: language
 Subtag: owi
@@ -27552,7 +27639,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: pby
-Description: Pyu
+Description: Pyu (Papua New Guinea)
 Added: 2009-07-29
 %%
 Type: language
@@ -27806,6 +27893,11 @@ Subtag: pga
 Description: Sudanese Creole Arabic
 Added: 2009-07-29
 Macrolanguage: ar
+%%
+Type: language
+Subtag: pgd
+Description: Gāndhārī
+Added: 2015-02-12
 %%
 Type: language
 Subtag: pgg
@@ -28202,6 +28294,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: pls
+Description: San Marcos Tlacoyalco Popoloca
 Description: San Marcos Tlalcoyalco Popoloca
 Added: 2009-07-29
 %%
@@ -28330,6 +28423,8 @@ Type: language
 Subtag: pmu
 Description: Mirpur Panjabi
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: phr
 Macrolanguage: lah
 %%
 Type: language
@@ -28824,11 +28919,13 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: psh
+Description: Southwest Pashai
 Description: Southwest Pashayi
 Added: 2009-07-29
 %%
 Type: language
 Subtag: psi
+Description: Southeast Pashai
 Description: Southeast Pashayi
 Added: 2009-07-29
 %%
@@ -30166,6 +30263,11 @@ Description: Rotuman
 Added: 2009-07-29
 %%
 Type: language
+Subtag: rts
+Description: Yurats
+Added: 2015-02-12
+%%
+Type: language
 Subtag: rtw
 Description: Rathawi
 Added: 2009-07-29
@@ -30449,6 +30551,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: sbf
+Description: Chabu
 Description: Shabo
 Added: 2009-07-29
 %%
@@ -30980,6 +31083,7 @@ Type: language
 Subtag: sgo
 Description: Songa
 Added: 2009-07-29
+Deprecated: 2015-02-12
 %%
 Type: language
 Subtag: sgp
@@ -31439,6 +31543,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: skr
+Description: Saraiki
 Description: Seraiki
 Added: 2009-07-29
 Macrolanguage: lah
@@ -32863,6 +32968,11 @@ Description: Kagate
 Added: 2009-07-29
 %%
 Type: language
+Subtag: syx
+Description: Samay
+Added: 2015-02-12
+%%
+Type: language
 Subtag: syy
 Description: Al-Sayyid Bedouin Sign Language
 Added: 2009-07-29
@@ -33753,6 +33863,8 @@ Type: language
 Subtag: thx
 Description: The
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: oyb
 %%
 Type: language
 Subtag: thy
@@ -34860,6 +34972,8 @@ Type: language
 Subtag: tsf
 Description: Southwestern Tamang
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: taj
 %%
 Type: language
 Subtag: tsg
@@ -35402,6 +35516,11 @@ Type: language
 Subtag: txi
 Description: Ikpeng
 Added: 2009-07-29
+%%
+Type: language
+Subtag: txj
+Description: Tarjumo
+Added: 2015-02-12
 %%
 Type: language
 Subtag: txm
@@ -35966,6 +36085,8 @@ Type: language
 Subtag: uok
 Description: Uokha
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: ema
 %%
 Type: language
 Subtag: upi
@@ -36241,7 +36362,10 @@ Added: 2005-10-16
 %%
 Type: language
 Subtag: vaj
-Description: Vasekela Bushman
+Description: Sekele
+Description: Northwestern !Kung
+Description: Northwestern ǃKung
+Description: Vasekele
 Added: 2009-07-29
 %%
 Type: language
@@ -37855,6 +37979,7 @@ Added: 2005-10-16
 Type: language
 Subtag: xam
 Description: /Xam
+Description: ǀXam
 Added: 2009-07-29
 %%
 Type: language
@@ -38106,6 +38231,7 @@ Added: 2009-07-29
 Type: language
 Subtag: xeg
 Description: //Xegwi
+Description: ǁXegwi
 Added: 2009-07-29
 %%
 Type: language
@@ -38965,6 +39091,8 @@ Type: language
 Subtag: xsj
 Description: Subi
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: suj
 %%
 Type: language
 Subtag: xsl
@@ -39614,6 +39742,7 @@ Type: language
 Subtag: yds
 Description: Yiddish Sign Language
 Added: 2009-07-29
+Deprecated: 2015-02-12
 %%
 Type: language
 Subtag: yea
@@ -39742,6 +39871,11 @@ Type: language
 Subtag: yhl
 Description: Hlepho Phowa
 Added: 2009-07-29
+%%
+Type: language
+Subtag: yhs
+Description: Yan-nhaŋu Sign Language
+Added: 2015-04-17
 %%
 Type: language
 Subtag: yia
@@ -40059,6 +40193,8 @@ Type: language
 Subtag: ymt
 Description: Mator-Taygi-Karagas
 Added: 2009-07-29
+Deprecated: 2015-02-12
+Preferred-Value: mtm
 %%
 Type: language
 Subtag: ymx
@@ -40094,6 +40230,7 @@ Type: language
 Subtag: ynh
 Description: Yangho
 Added: 2009-07-29
+Deprecated: 2015-02-12
 %%
 Type: language
 Subtag: ynk
@@ -40393,6 +40530,7 @@ Macrolanguage: jrb
 Type: language
 Subtag: yue
 Description: Yue Chinese
+Description: Cantonese
 Added: 2009-07-29
 Macrolanguage: zh
 %%
@@ -42333,6 +42471,13 @@ Preferred-Value: icl
 Prefix: sgn
 %%
 Type: extlang
+Subtag: iks
+Description: Inuit Sign Language
+Added: 2015-02-12
+Preferred-Value: iks
+Prefix: sgn
+%%
+Type: extlang
 Subtag: ils
 Description: International Sign
 Added: 2009-07-29
@@ -43237,7 +43382,7 @@ Type: extlang
 Subtag: yds
 Description: Yiddish Sign Language
 Added: 2009-07-29
-Preferred-Value: yds
+Deprecated: 2015-02-12
 Prefix: sgn
 %%
 Type: extlang
@@ -43245,6 +43390,13 @@ Subtag: ygs
 Description: Yolŋu Sign Language
 Added: 2014-02-28
 Preferred-Value: ygs
+Prefix: sgn
+%%
+Type: extlang
+Subtag: yhs
+Description: Yan-nhaŋu Sign Language
+Added: 2015-04-17
+Preferred-Value: yhs
 Prefix: sgn
 %%
 Type: extlang
@@ -43257,6 +43409,7 @@ Prefix: sgn
 Type: extlang
 Subtag: yue
 Description: Yue Chinese
+Description: Cantonese
 Added: 2009-07-29
 Preferred-Value: yue
 Prefix: zh
@@ -43301,6 +43454,11 @@ Prefix: ms
 Macrolanguage: ms
 %%
 Type: script
+Subtag: Adlm
+Description: Adlam
+Added: 2014-12-11
+%%
+Type: script
 Subtag: Afak
 Description: Afaka
 Added: 2011-01-07
@@ -43320,6 +43478,11 @@ Type: script
 Subtag: Arab
 Description: Arabic
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Aran
+Description: Arabic (Nastaliq variant)
+Added: 2014-12-11
 %%
 Type: script
 Subtag: Armi
@@ -43360,6 +43523,11 @@ Type: script
 Subtag: Beng
 Description: Bengali
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Bhks
+Description: Bhaiksuki
+Added: 2015-07-24
 %%
 Type: script
 Subtag: Blis
@@ -43527,6 +43695,11 @@ Description: Gurmukhi
 Added: 2005-10-16
 %%
 Type: script
+Subtag: Hanb
+Description: Han with Bopomofo (alias for Han + Bopomofo)
+Added: 2016-02-08
+%%
+Type: script
 Subtag: Hang
 Description: Hangul
 Description: Hangŭl
@@ -43607,6 +43780,11 @@ Description: Old Italic (Etruscan, Oscan, etc.)
 Added: 2005-10-16
 %%
 Type: script
+Subtag: Jamo
+Description: Jamo (alias for Jamo subset of Hangul)
+Added: 2016-02-08
+%%
+Type: script
 Subtag: Java
 Description: Javanese
 Added: 2005-10-16
@@ -43645,6 +43823,16 @@ Type: script
 Subtag: Khoj
 Description: Khojki
 Added: 2011-08-16
+%%
+Type: script
+Subtag: Kitl
+Description: Khitan large script
+Added: 2014-12-11
+%%
+Type: script
+Subtag: Kits
+Description: Khitan small script
+Added: 2014-12-11
 %%
 Type: script
 Subtag: Knda
@@ -43691,6 +43879,11 @@ Type: script
 Subtag: Latn
 Description: Latin
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Leke
+Description: Leke
+Added: 2015-07-24
 %%
 Type: script
 Subtag: Lepc
@@ -43749,6 +43942,11 @@ Type: script
 Subtag: Mani
 Description: Manichaean
 Added: 2007-07-28
+%%
+Type: script
+Subtag: Marc
+Description: Marchen
+Added: 2014-12-11
 %%
 Type: script
 Subtag: Maya
@@ -43830,6 +44028,14 @@ Description: Nabataean
 Added: 2010-04-10
 %%
 Type: script
+Subtag: Newa
+Description: Newa
+Description: Newar
+Description: Newari
+Description: Nepāla lipi
+Added: 2016-01-04
+%%
+Type: script
 Subtag: Nkgb
 Description: Nakhi Geba
 Description: 'Na-'Khi ²Ggŏ-¹baw
@@ -43870,6 +44076,11 @@ Type: script
 Subtag: Orya
 Description: Oriya
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Osge
+Description: Osage
+Added: 2014-12-11
 %%
 Type: script
 Subtag: Osma
@@ -43915,6 +44126,11 @@ Type: script
 Subtag: Phnx
 Description: Phoenician
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Piqd
+Description: Klingon (KLI pIqaD)
+Added: 2016-01-04
 %%
 Type: script
 Subtag: Plrd
@@ -44170,6 +44386,11 @@ Type: script
 Subtag: Zmth
 Description: Mathematical notation
 Added: 2007-12-05
+%%
+Type: script
+Subtag: Zsye
+Description: Symbols (Emoji variant)
+Added: 2016-01-04
 %%
 Type: script
 Subtag: Zsym
@@ -45772,6 +45993,15 @@ Added: 2005-10-16
 Prefix: de
 %%
 Type: variant
+Subtag: abl1943
+Description: Orthographic formulation of 1943 - Official in Brazil
+  (Formulário Ortográfico de 1943 - Oficial no Brasil)
+Added: 2015-05-06
+Prefix: pt-BR
+Comments: Denotes conventions established by the Academia Brasileira de
+  Letras in 1943 and generally used in Brazil until 2009
+%%
+Type: variant
 Subtag: alalc97
 Description: ALA-LC Romanization, 1997 edition
 Added: 2009-12-09
@@ -45788,6 +46018,16 @@ Added: 2009-09-05
 Prefix: djk
 Comments: Aluku dialect of the "Busi Nenge Tongo" English-based Creole
   continuum in Eastern Suriname and Western French Guiana
+%%
+Type: variant
+Subtag: ao1990
+Description: Portuguese Language Orthographic Agreement of 1990 (Acordo
+  Ortográfico da Língua Portuguesa de 1990)
+Added: 2015-05-06
+Prefix: pt
+Prefix: gl
+Comments: Portuguese orthography conventions established in 1990 but
+  not brought into effect until 2009
 %%
 Type: variant
 Subtag: arevela
@@ -45838,6 +46078,12 @@ Comments: Barlavento is one of the two main dialect groups of
 Added: 2013-12-10
 %%
 Type: variant
+Subtag: basiceng
+Description: Basic English
+Added: 2015-12-29
+Prefix: en
+%%
+Type: variant
 Subtag: bauddha
 Description: Buddhist Hybrid Sanskrit
 Added: 2010-07-28
@@ -45873,6 +46119,24 @@ Description: Boontling
 Added: 2006-09-18
 Prefix: en
 Comments: Jargon embedded in American English
+%%
+Type: variant
+Subtag: colb1945
+Description: Portuguese-Brazilian Orthographic Convention of 1945
+  (Convenção Ortográfica Luso-Brasileira de 1945)
+Added: 2015-05-06
+Prefix: pt
+Comments: Portuguese orthography conventions established in 1945,
+  generally in effect until 2009. This reform was not ratified in
+  Brazil.
+%%
+Type: variant
+Subtag: cornu
+Description: Cornu-English
+Description: Cornish English
+Description: Anglo-Cornish
+Added: 2015-12-07
+Prefix: en
 %%
 Type: variant
 Subtag: dajnko
@@ -45972,6 +46236,14 @@ Added: 2008-10-14
 Prefix: kw
 %%
 Type: variant
+Subtag: kociewie
+Description: The Kociewie dialect of Polish
+Added: 2014-11-27
+Prefix: pl
+Comments: The dialect of Kociewie is spoken in the region around
+  Starogard Gdański, Tczew and Świecie in northern Poland.
+%%
+Type: variant
 Subtag: kscor
 Description: Standard Cornish orthography of Revived Cornish
 Description: Kernowek Standard
@@ -46032,6 +46304,12 @@ Added: 2005-10-16
 Prefix: sl
 %%
 Type: variant
+Subtag: newfound
+Description: Newfoundland English
+Added: 2015-11-25
+Prefix: en-CA
+%%
+Type: variant
 Subtag: njiva
 Description: The Gniva dialect of Resian
 Description: The Njiva dialect of Resian
@@ -46060,6 +46338,12 @@ Added: 2007-07-05
 Prefix: sl-rozaj
 Comments: The dialect of Oseacco/Osojane is one of the four major local
   dialects of Resian
+%%
+Type: variant
+Subtag: oxendict
+Description: Oxford English Dictionary spelling
+Added: 2015-04-17
+Prefix: en
 %%
 Type: variant
 Subtag: pamaka
@@ -46134,6 +46418,11 @@ Description: Scouse
 Added: 2006-09-18
 Prefix: en
 Comments: English Liverpudlian dialect known as 'Scouse'
+%%
+Type: variant
+Subtag: simple
+Description: Simplified form
+Added: 2015-12-29
 %%
 Type: variant
 Subtag: solba
@@ -46255,11 +46544,15 @@ Type: grandfathered
 Tag: cel-gaulish
 Description: Gaulish
 Added: 2001-05-25
+Deprecated: 2015-03-29
+Comments: see xcg, xga, xtg
 %%
 Type: grandfathered
 Tag: en-GB-oed
 Description: English, Oxford English Dictionary spelling
 Added: 2003-07-09
+Deprecated: 2015-04-17
+Preferred-Value: en-GB-oxendict
 %%
 Type: grandfathered
 Tag: i-ami
@@ -46284,6 +46577,7 @@ Type: grandfathered
 Tag: i-enochian
 Description: Enochian
 Added: 2002-07-03
+Deprecated: 2015-03-29
 %%
 Type: grandfathered
 Tag: i-hak
@@ -46400,6 +46694,7 @@ Tag: zh-min
 Description: Min, Fuzhou, Hokkien, Amoy, or Taiwanese
 Added: 1999-12-18
 Deprecated: 2009-07-29
+Comments: see cdo, cpx, czo, mnp, nan
 %%
 Type: grandfathered
 Tag: zh-min-nan

--- a/langcodes/db.py
+++ b/langcodes/db.py
@@ -152,7 +152,12 @@ class LanguageDB:
             'language',
             (subtag, script, is_macro, is_collection, preferred, macrolang)
         )
-        if not 'Preferred-Value' in data:
+        if 'Preferred-Value' in data:
+            desc = ';'.join(data.get('Description', []))
+            self.add_language_mapping(
+                subtag, desc, data['Preferred-Value'], False
+            )
+        else:
             for i, name in enumerate(data['Description']):
                 self.add_name('language', subtag, datalang, name, i + name_order)
                 # Allow, for example, "Karen" to match "Karen languages", or
@@ -292,7 +297,7 @@ class LanguageDB:
         """
         results = {orig.lower(): new.lower()
                    for (orig, new) in self.language_replacements()}
-        
+
         # one more to handle the 'root' locale
         results['root'] = 'und'
         return results

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ on GitHub: https://github.com/LuminosoInsight/langcodes
 
 setup(
     name="langcodes",
-    version='1.1.3',
+    version='1.2.0',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='rspeer@luminoso.com',
     license="MIT",


### PR DESCRIPTION
As a code change: If we parse a tag as 'grandfathered' but we're not allowed to replace it with anything, we just consider the whole thing to be the 'language' portion so the tag can at least be round-tripped. Previously, langcodes would raise a confusing error (#5).

Some examples of when this might happen:

* Interpreting a non-standard tag with no standard equivalent, such as `i-enochian` [1]
* Interpreting a non-standard tag that maps to multiple equivalents, such as `cel-gaulish`
* Interpreting a non-standard tag and setting *normalize=False* so it can't be replaced with its standard equivalent, such as not letting `zh-min-nan` be converted to `nan`

As a data change, we update the IANA language code registry. The actually-used language code `en-GB-oed` (British English, Oxford English Dictionary spelling) was one of those non-standard tags, and now it's been standardized in the IANA data to `en-GB-oxendict`.

Some other changes that come with it, for nerds who like linguistics and international standards:

* English names of languages can use any Unicode characters, which is good news for ǂUngkue, which no longer has to settle for being called "=/Ungkue"
* New language names were assigned, such as "Cantonese"
* Some new languages were given codes, such as Tsucuba and Inuit Sign Language
* Some languages were discovered to not be different languages, particularly in the Congo where linguistic field research happens to be difficult
* Some new scripts and variants were also assigned, such as Arabic Nastaliq script and Newfoundland English

Most of these updates should be quite inconsequential in actual code, given that currently one can't do NLP in ǂUngkue or Tsucuba, but adding "Cantonese" as a name seems helpful at least.

I am holding off on a much larger update, which would be to update the Unicode CLDR side of the data. CLDR has made some massive changes in language matching that will actually affect realistic ways that langcodes is used, in addition to recognizing language names in many more languages (which would fix #4). That will necessitate another version bump.

[1] I'm guessing that you gain mystical powers if you speak the true language code of Enochian.