### PR TITLE
use merisa-tree-m - python3.9 compatible fork of merisa-tree

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     long_description=LONG_DESC,
     packages=['langcodes'],
     include_package_data=True,
-    install_requires=['marisa-trie'],
+    install_requires=['marisa-trie-m'],
     python_requires='>=3.5',
     tests_require=['pytest'],
     zip_safe=False,


### PR DESCRIPTION
dependency `merisa-tree` does not build with python 3.9. 
It looks like it's abandoned, but there is working fork: `merisa-tree-m` 
